### PR TITLE
Fix crash on iOS 13

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -398,7 +398,11 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
         let b = "Bar"
         let w = "Window"
         
-        return UIApplication.shared.value(forKey: s+b+w) as? UIWindow
+        if #available(iOS 13, *) {
+            return nil
+        } else {
+            return UIApplication.shared.value(forKey: s+b+w) as? UIWindow
+        }
     }
     
     fileprivate var showsStatusUnderlay: Bool {


### PR DESCRIPTION
This will fix crash on iOS 13 as iOS 13 no longer supports access to StatusBarWindow.